### PR TITLE
fix error

### DIFF
--- a/Source/DrawTextView.swift
+++ b/Source/DrawTextView.swift
@@ -20,6 +20,9 @@ public class DrawTextView: UIView {
     
     var text: String! {
         didSet {
+            if textLabel.text == text {
+                return
+            }
             textLabel.text = text
             sizeTextLabel()
         }


### PR DESCRIPTION
If quit TextEditView without making any change, the size of
DrawTextView will be wrong sometimes.(eg: font with larger space
between characters will be cut off).

Have a check to see if resize is necessary will fix the issue
